### PR TITLE
Adds graceful shutdown and fixes in Makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 certs_windows:
-	mkdir "./cmd/proxy/.cert"
+	mkdir -p "./cmd/proxy/.cert"
 	# Create CA (certificate authority)
 	openssl ecparam -out ./cmd/proxy/.cert/ca.key -name prime256v1 -genkey
 	openssl req -new -sha256 -key ./cmd/proxy/.cert/ca.key -out ./cmd/proxy/.cert/ca.csr
@@ -12,7 +12,7 @@ certs_windows:
 	openssl x509 -in ./cmd/proxy/.cert/server.crt -text -noout
 
 certs:
-	mkdir "./cmd/proxy/.cert"
+	mkdir -p "./cmd/proxy/.cert"
 	# Create CA (certificate authority)
 	openssl ecparam -out ./cmd/proxy/.cert/ca.key -name prime256v1 -genkey
 	openssl req -new -sha256 -key ./cmd/proxy/.cert/ca.key -out ./cmd/proxy/.cert/ca.csr


### PR DESCRIPTION
Graceful shutdown for the server is required so the OS can free the server port once an interrupt is received. 
The `-p` flag in mkdir is required so it dooesn't throw an error if the cert directory already exists.